### PR TITLE
Fix evaluation for detectron (api updates in evaluation.py).

### DIFF
--- a/voxaboxen/evaluation/evaluation.py
+++ b/voxaboxen/evaluation/evaluation.py
@@ -531,7 +531,7 @@ def predict_and_generate_manifest(model, dataloader_dict, args, verbose = True):
   manifest = pd.DataFrame({'filename' : fns, 'fwd_predictions_fp' : fwd_predictions_fps, 'bck_predictions_fp' : bck_predictions_fps, 'annotations_fp' : annotations_fps, 'duration_sec' : durations})
   return manifest
 
-def evaluate_based_on_manifest(manifest, args, output_dir, iou, class_threshold, comb_discard_threshold):
+def evaluate_based_on_manifest(manifest, args, output_dir, iou, class_threshold, comb_discard_threshold=0.5):
   pred_types = ('fwd', 'bck', 'comb', 'match') if args.bidirectional else ('fwd',)
   metrics = {p:{} for p in pred_types}
   conf_mats = {p:{} for p in pred_types}


### PR DESCRIPTION
This PR updates the evaluation code for the detectron (comparison) script. Just updates to work with changes in the api for evaluation.py.

Without these changes you'll get this error at the end of detectron training (recommend setting to 1 epoch because error doesn't happen till the end):

```
100%|███████████████████████████████████████████████████████████████████████████████████| 967/967 [09:24<00:00,  1.71it/s]
Calculating metrics against manual annotations.
Traceback (most recent call last):
  File "/app/src/main.py", line 30, in <module>
    main(mode, args)
  File "/app/src/main.py", line 20, in main
    train(args)
  File "/app/src/voxaboxen/comparisons/train.py", line 51, in train
    run_evaluation(trainer.model, cfg.SOUND_EVENT.train_info_fp, cfg, "train_results")
  File "/app/src/voxaboxen/comparisons/evaluate.py", line 104, in run_evaluation
    evaluate_based_on_manifest(
TypeError: evaluate_based_on_manifest() missing 1 required positional argument: 'comb_discard_threshold'

```