### PR TITLE
Fix early stopping when using segmentation based model.

### DIFF
--- a/voxaboxen/training/train.py
+++ b/voxaboxen/training/train.py
@@ -71,7 +71,10 @@ def train(model, args):
       scheduler.step()
 
       if use_val and args.early_stopping:
-        current_f1 = eval_scores['comb']['f1'] if model.is_bidirectional else eval_scores['fwd']['f1']
+        if hasattr(args, "segmentation_based") and args.segmentation_based:
+          current_f1 = eval_scores['fwd']['f1_seg']
+        else:
+          current_f1 = eval_scores['comb']['f1'] if model.is_bidirectional else eval_scores['fwd']['f1']
         if current_f1 > best_f1:
           print('found new best model')
           best_f1 = current_f1


### PR DESCRIPTION
Early stopping isn't finding best model when using the segmentation based setting.

I noticed that early stopping wasn't using the segmented f1 score (fwdF1_seg) when using segmentation mode. Fix is pretty trivial.

Here's an example, notice that "found new best model" is only being printed out when `fwdF1` improves, not the segmented f1 score. Epoch 8 is when a new best model should have been found.

```
root@717c31fdff54:/app/src# python main.py train-model --project-config-fp=projects/AnuraSet/project_config.yaml --name=demo --lr=.00005 --batch-size=4 --n-epochs=10 --early-stopping --segmentation-based --rho=1 --overwrite
Epoch 0 | val@0.5IoU:
fwdprec: 0.517 fwdrec: 0.504 fwdF1: 0.507 fwdprec_seg: 0.994 fwdrec_seg: 0.525 fwdF1_seg: 0.547
found new best model
Epoch 1
-------------------------------
loss 0.00380, det 0.00000, reg 0.00000, class 0.00380: 100%|██████████████████████████| 4103/4103 [01:25<Epoch 1 | Train loss: 0.006
Epoch 1 | val@0.5IoU:
fwdprec: 0.574 fwdrec: 0.555 fwdF1: 0.563 fwdprec_seg: 0.991 fwdrec_seg: 0.600 fwdF1_seg: 0.667
found new best model
Epoch 2
-------------------------------
loss 0.00633, det 0.00000, reg 0.00000, class 0.00633: 100%|██████████████████████████| 4103/4103 [01:25<Epoch 2 | Train loss: 0.005
Epoch 2 | val@0.5IoU:
fwdprec: 0.598 fwdrec: 0.589 fwdF1: 0.593 fwdprec_seg: 0.992 fwdrec_seg: 0.639 fwdF1_seg: 0.717 
found new best model
Epoch 3
-------------------------------
loss 0.00026, det 0.00000, reg 0.00000, class 0.00026: 100%|██████████████████████████| 4103/4103 [03:50<00:00, 17.78it/s]
Epoch 3 | Train loss: 0.002
Epoch 3 | val@0.5IoU:
fwdprec: 0.937 fwdrec: 0.802 fwdF1: 0.857 fwdprec_seg: 0.970 fwdrec_seg: 0.893 fwdF1_seg: 0.928
found new best model
Epoch 4
-------------------------------
loss 0.00045, det 0.00000, reg 0.00000, class 0.00045: 100%|██████████████████████████| 4103/4103 [03:50<00:00, 17.78it/s]
Epoch 4 | Train loss: 0.001
Epoch 4 | val@0.5IoU:
fwdprec: 0.900 fwdrec: 0.813 fwdF1: 0.851 fwdprec_seg: 0.961 fwdrec_seg: 0.897 fwdF1_seg: 0.927
Epoch 5
-------------------------------
loss 0.00021, det 0.00000, reg 0.00000, class 0.00021: 100%|██████████████████████████| 4103/4103 [03:54<00:00, 17.50it/s]
Epoch 5 | Train loss: 0.001
Epoch 5 | val@0.5IoU:
fwdprec: 0.942 fwdrec: 0.838 fwdF1: 0.883 fwdprec_seg: 0.980 fwdrec_seg: 0.918 fwdF1_seg: 0.947
found new best model
Epoch 6
-------------------------------
loss 0.00036, det 0.00000, reg 0.00000, class 0.00036: 100%|██████████████████████████| 4103/4103 [03:53<00:00, 17.60it/s]
Epoch 6 | Train loss: 0.000
Epoch 6 | val@0.5IoU:
fwdprec: 0.924 fwdrec: 0.842 fwdF1: 0.879 fwdprec_seg: 0.975 fwdrec_seg: 0.917 fwdF1_seg: 0.944
Epoch 7
-------------------------------
loss 0.00035, det 0.00000, reg 0.00000, class 0.00035: 100%|██████████████████████████| 4102/4102 [03:54<00:00, 17.52it/s]
Epoch 7 | Train loss: 0.000
Epoch 7 | val@0.5IoU:
fwdprec: 0.927 fwdrec: 0.837 fwdF1: 0.877 fwdprec_seg: 0.978 fwdrec_seg: 0.919 fwdF1_seg: 0.947
Epoch 8
-------------------------------
loss 0.00005, det 0.00000, reg 0.00000, class 0.00005: 100%|██████████████████████████| 4103/4103 [03:54<00:00, 17.48it/s]
Epoch 8 | Train loss: 0.000
Epoch 8 | val@0.5IoU:
fwdprec: 0.932 fwdrec: 0.838 fwdF1: 0.879 fwdprec_seg: 0.976 fwdrec_seg: 0.926 fwdF1_seg: 0.949
Epoch 9
-------------------------------
loss 0.00014, det 0.00000, reg 0.00000, class 0.00014: 100%|██████████████████████████| 4103/4103 [03:54<00:00, 17.53it/s]
Epoch 9 | Train loss: 0.000
Epoch 9 | val@0.5IoU:
fwdprec: 0.922 fwdrec: 0.839 fwdF1: 0.876 fwdprec_seg: 0.973 fwdrec_seg: 0.928 fwdF1_seg: 0.949

```